### PR TITLE
openAPIのレシピ投稿のエンドポイントの設計

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -8,9 +8,17 @@ servers:
 paths:
   /post-recipe:
     post:
+      security:
+        - bearerAuth: []
       tags: 
         - post
       description: post recipe
+      parameters:
+        - in: header
+          name: Authorization
+          schema:
+            $ref: '#/components/schemas/Authorization'
+          required: true
       requestBody:
         content:
           application/json:
@@ -35,9 +43,11 @@ paths:
 
 
 
-
 components:
   schemas:
+    Authorization:
+      description: "bearer token"
+      example: "Bearer xxxxxxxxxxxxxxxxxxx"
     PostRecipe: 
       type: object
       required:
@@ -89,4 +99,10 @@ components:
             properties:
               content:  
                 type: string
+  securitySchemes:
+    bearerAuth:            # arbitrary name for the security scheme
+      type: http
+      scheme: bearer
+      bearerFormat: JWT 
+  
         

--- a/openapi.yml
+++ b/openapi.yml
@@ -43,16 +43,30 @@ components:
       required:
         - user_id
         - name
+        - ingredients
         - seasonings
         - steps
       properties:
         user_id:
-          type: string
+          type: integer
         name:
           type: string
+        ingredients:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - quantity
+            properties:
+              name:
+                type: string
+              quantity: 
+                type: number
+                format: string
         description:
           type: string
-        time_required_m: 
+        time_required_min: 
           type: integer
         seasonings:
           type: array

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,6 +16,15 @@ paths:
           application/json:
             schema: 
               $ref: '#/components/schemas/PostRecipe'
+            example:
+              user_id: 1
+              name: "おつまみキャベツ"
+              ingredients: [{"name": "キャベツ", "quantity":"1/4"}]
+              description: "簡単にばくばく食べられます"
+              time_required_min: 5
+              seasonings: [{"name": "にんにく","quantity":"適量"},{"name": "塩","quantity":"適量"},{"name": "ごま油","quantity":"適量"}]
+              steps: [{"content":"キャベツを切る"},{"content":"ジップロックに切ったキャベツと調味料を全部入れて混ぜる"}]
+
       responses:
         '200':
           description: OK

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,7 +6,7 @@ info:
 servers:
   - url: https://api.server.test/v1
 paths:
-  /post-recipe:
+  /recipes:
     post:
       security:
         - bearerAuth: []

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,69 @@
+openapi: '3.0.2'
+info:
+  title: hitotsumami
+  description: find recipe from some ingredients
+  version: '1.0'
+servers:
+  - url: https://api.server.test/v1
+paths:
+  /post-recipe:
+    post:
+      tags: 
+        - post
+      description: post recipe
+      requestBody:
+        content:
+          application/json:
+            schema: 
+              $ref: '#/components/schemas/PostRecipe'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request 
+        '500':
+          description: Internal Server Error
+
+
+
+
+components:
+  schemas:
+    PostRecipe: 
+      type: object
+      required:
+        - user_id
+        - name
+        - seasonings
+        - steps
+      properties:
+        user_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        time_required_m: 
+          type: integer
+        seasonings:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - quantity
+            properties:
+              name: 
+                type: string
+              quantity:
+                type: string
+        steps:
+          type: array
+          items:
+            type: object
+            required:
+              - content
+            properties:
+              content:  
+                type: string
+        

--- a/openapi.yml
+++ b/openapi.yml
@@ -66,8 +66,7 @@ components:
               name:
                 type: string
               quantity: 
-                type: number
-                format: string
+                type: string
         description:
           type: string
         time_required_min: 

--- a/openapi.yml
+++ b/openapi.yml
@@ -11,7 +11,7 @@ paths:
       security:
         - bearerAuth: []
       tags: 
-        - post
+        - recipe
       description: post recipe
       parameters:
         - in: header
@@ -24,18 +24,13 @@ paths:
           application/json:
             schema: 
               $ref: '#/components/schemas/PostRecipe'
-            example:
-              user_id: 1
-              name: "おつまみキャベツ"
-              ingredients: [{"name": "キャベツ", "quantity":"1/4"}]
-              description: "簡単にばくばく食べられます"
-              time_required_min: 5
-              seasonings: [{"name": "にんにく","quantity":"適量"},{"name": "塩","quantity":"適量"},{"name": "ごま油","quantity":"適量"}]
-              steps: [{"content":"キャベツを切る"},{"content":"ジップロックに切ったキャベツと調味料を全部入れて混ぜる"}]
-
       responses:
-        '200':
+        '201':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostRecipe'
         '400':
           description: Bad Request 
         '500':
@@ -51,14 +46,13 @@ components:
     PostRecipe: 
       type: object
       required:
-        - user_id
         - name
+        - description
+        - time_required_min
         - ingredients
         - seasonings
         - steps
       properties:
-        user_id:
-          type: integer
         name:
           type: string
         ingredients:
@@ -99,6 +93,14 @@ components:
             properties:
               content:  
                 type: string
+      example:
+              name: "おつまみキャベツ"
+              ingredients: [{"name": "キャベツ", "quantity":"1/4"}]
+              description: "簡単にばくばく食べられます"
+              time_required_min: 5
+              seasonings: [{"name": "にんにく","quantity":"適量"},{"name": "塩","quantity":"適量"},{"name": "ごま油","quantity":"適量"}]
+              steps: [{"content":"キャベツを切る"},{"content":"ジップロックに切ったキャベツと調味料を全部入れて混ぜる"}]
+
   securitySchemes:
     bearerAuth:            # arbitrary name for the security scheme
       type: http


### PR DESCRIPTION
## やったこと

- レシピを投稿するAPIの設計をした。
    - Path /post-recipe
    - Method: POST
- リクエスト例は下記
### リクエスト例
```
{
  "user_id": 1,
  "name": "おつまみキャベツ",
  "ingredients": [
    {
      "name": "キャベツ",
      "quantity": "1/4"
    }
  ],
  "description": "簡単にばくばく食べられます",
  "time_required_min": 5,
  "seasonings": [
    {
      "name": "にんにく",
      "quantity": "適量"
    },
    {
      "name": "塩",
      "quantity": "適量"
    },
    {
      "name": "ごま油",
      "quantity": "適量"
    }
  ],
  "steps": [
    {
      "content": "キャベツを切る"
    },
    {
      "content": "ジップロックに切ったキャベツと調味料を全部入れて混ぜる"
    }
  ]
}
```

## やらないこと
なし

## できるようになること（ユーザ目線）

レシピ投稿の実装の際に作るものが明白になる。

## できなくなること（ユーザ目線）

なし
## 動作確認

openAPI editorにて動作することは確認
## その他

- Openapiファイルの命名をどうするのが正解かわからず、とりあえずこのように置いておきました。ベターな書き方を教えてください。
- 所要時間などレシピとしてのテイはなすが、非ヌルであってほしくはないものはrequiredの方がいいですか？
- time_requiredが単位がなくわかりづらかったので、time_required_minにしました。