### PR TITLE
openAPIのログイン関連のエンドポイントの設計

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -125,7 +125,18 @@ paths:
         content:
           application/json:
             schema: 
-              $ref: '#/components/schemas/User'
+              type: object
+              required:
+                - mail_address
+                - password
+              properties:
+                mail_address:
+                  type: string
+                  example: 'aaa@example.com'
+                password:
+                  type: string
+                  format: password
+                  example: 'password'
       responses:
         '200':
           description: Successful login

--- a/openapi.yml
+++ b/openapi.yml
@@ -167,8 +167,8 @@ paths:
             $ref: '#/components/schemas/Authorization'
           required: true
       responses:
-        '200':
-          description: deleted
+        '204':
+          description: no contents
         '401':  
           description: Unauthorized
         '500':

--- a/openapi.yml
+++ b/openapi.yml
@@ -93,6 +93,76 @@ paths:
         '500':
           description: Internal Server Error
 
+  /users:
+    post: 
+      summary: user registration 
+      tags: 
+        - users
+      requestBody:
+        content:
+          application/json:
+            schema: 
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: complete registration
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Bad Request 
+        '500':
+          description: Internal Server Error
+
+
+  /login:
+    post: 
+      summary: user login
+      tags: 
+        - users
+      requestBody:
+        content:
+          application/json:
+            schema: 
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: Successful login
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - token
+                properties:
+                  token:
+                    type: string
+                    description: bearer token
+        '401':
+          description: Unautholized
+        '500':
+          description: Internal Server Error
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - users
+      summary: user logout
+      parameters:
+        - in: header
+          name: Authorization
+          schema:
+            $ref: '#/components/schemas/Authorization'
+          required: true
+      responses:
+        '200':
+          description: deleted
+        '401':  
+          description: Unautholized
+        '500':
+          description: Internal Server Error
+      
 
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -151,7 +151,7 @@ paths:
                     type: string
                     description: bearer token
         '401':
-          description: Unautholized
+          description: Unauthorized
         '500':
           description: Internal Server Error
     delete:
@@ -170,7 +170,7 @@ paths:
         '200':
           description: deleted
         '401':  
-          description: Unautholized
+          description: Unauthorized
         '500':
           description: Internal Server Error
       

--- a/openapi.yml
+++ b/openapi.yml
@@ -164,6 +164,31 @@ components:
                 type: string
                 example: "材料を切る"
 
+
+    User:
+      type: object
+      required:
+        - id
+        - name
+        - mail_address
+        - password
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name: 
+          type: string
+          example: 'user'
+        mail_address:
+          type: string
+          example: 'aaa@example.com'
+        password:
+          type: string
+          format: password
+          writeOnly: true
+          example: 'password'
+
   securitySchemes:
     bearerAuth:            # arbitrary name for the security scheme
       type: http


### PR DESCRIPTION
## やったこと
* このプルリクで何をしたのか？

- ユーザー登録するAPIの設計
    - path /users/registration
    - method POST
- ログイン、ログアウトするAPIの設計
    - path /login
    - method POST
        - ログインする
    - method DELETE
        - ログアウトする
## やらないこと
* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

なし
## できるようになること（ユーザ目線）
* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

ログイン関連の開発するときにAPI設計がみやすく明確になる。
## できなくなること（ユーザ目線）
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

なし
## 動作確認
* どのような動作確認を行ったのか？　結果はどうか？

openapi live editorで動作確認
## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

- /login を/users/loginにするか迷いました。迷った挙句シンプルな方を取りました。ご意見いただければと思います。
- またlogoutを/loginのDELETEメソッドで設計しました。
https://www.ibm.com/docs/ja/ibm-mq/9.1?topic=resources-login
https://qiita.com/wasnot/items/949c6c4efe43ca0fa1cc
この辺りを参考にしました。ご意見伺えればと思います。
- コミットうっかりしてて、レシピ閲覧の方のコミットも載ってしまいました...